### PR TITLE
Admin create option

### DIFF
--- a/app/Category.php
+++ b/app/Category.php
@@ -13,6 +13,6 @@ class Category extends Model
 
     public function words_category_id()
     {
-        return $this->belongsToMany('App\Category', 'words', 'category_id');
+        return $this->hasMany('App\Word', 'category_id', 'id');
     }
 }

--- a/app/Http/Controllers/WordController.php
+++ b/app/Http/Controllers/WordController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Category;
 use App\Word;
+use App\Option;
 use App\Http\Requests\WordRequest;
 
 class WordController extends Controller
@@ -28,7 +29,7 @@ class WordController extends Controller
 
     public function store_word_admin($id, WordRequest $request)
     {
-        Word::create([
+        $word = Word::create([
             'category_id' => $id,
             'japanese' => $request['japanese'],
             'difficulty' => $request['difficulty'],
@@ -37,7 +38,7 @@ class WordController extends Controller
 
         $request->session()->regenerateToken();
 
-        return redirect()->route('words_admin', ['id' => $id]);
+        return redirect()->route('add_option_admin',['word_id'=>$word->id]);
     }
 
     public function edit_word_admin($word_id)
@@ -54,7 +55,7 @@ class WordController extends Controller
         $word->difficulty = $request->input('difficulty');
         $word->save();
 
-        return redirect()->route('words_admin', ['id' => $word->category_id]);
+        return redirect()->route('edit_option_admin', ['word_id' => $word->id]);
     }
 
     public function delete_word_admin($word_id)
@@ -63,5 +64,58 @@ class WordController extends Controller
         $word->delete();
 
         return back();
+    }
+
+    public function add_option_admin($word_id)
+    {
+        $word = Word::find($word_id);
+        return view('admin.add_option',compact('word'));
+    }
+
+    public function store_option_admin($word_id,Request $request)
+    {
+        $word = Word::find($word_id);
+
+        for ($i = 1; $i <= 3; $i++) {
+            if ($i == 1) {
+                $_result = true;
+            }else {
+                $_result = false;
+            }
+                $option = 'option'.$i;
+                Option::create([
+                    'word_id' => $word->id,
+                    'option_name' => $request->$option,
+                    'true_or_false' => $_result
+                ]);
+        }
+
+        $request->session()->regenerateToken();
+        
+        return redirect()->route('words_admin', ['id' => $word->category_id]);
+    }
+
+    public function edit_option_admin($word_id)
+    {
+        $word = Word::find($word_id);
+        $options = $word->options_word_id()->get();
+
+        return view('admin.edit_option', compact('options','word'));
+    }
+
+    public function update_option_admin($word_id,  Request $request)
+    {
+        $word = Word::find($word_id);
+        $options = $word->options_word_id()->get();
+
+        $i = 1;
+        foreach ($options as $option) {
+            $name = 'option'.$i;
+            $option->option_name = $request->input($name);
+            $option->save();
+            $i += 1;
+        }
+
+        return redirect()->route('words_admin', ['id' => $word->category_id]);
     }
 }

--- a/app/Option.php
+++ b/app/Option.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Option extends Model
+{
+    protected $fillable = [
+        'word_id', 'option_name', 'true_or_false',
+    ];
+}

--- a/app/Word.php
+++ b/app/Word.php
@@ -9,4 +9,9 @@ class Word extends Model
     protected $fillable = [
         'japanese', 'category_id', 'difficulty', 'explain',
     ];
+
+    public function options_word_id()
+    {
+        return $this->hasMany('App\Option', 'word_id', 'id');
+    }
 }

--- a/database/migrations/2019_05_30_031248_create_options_table.php
+++ b/database/migrations/2019_05_30_031248_create_options_table.php
@@ -18,7 +18,7 @@ class CreateOptionsTable extends Migration
             $table->unsignedInteger('word_id');
             $table->foreign('word_id')->references('id')->on('words')->onDelete('cascade');
             $table->string('option_name');
-            $table->string('ture_or_false');
+            $table->boolean('true_or_false');
             $table->timestamps();
         });
     }

--- a/resources/views/admin/admin_categories.blade.php
+++ b/resources/views/admin/admin_categories.blade.php
@@ -25,7 +25,7 @@
                 <tr>
                     <th scope="row">{{ $category->category }}</th>
                     <td>{{ $category->describe }}</td>
-                    <td></td>
+                    <td>{{ $category->words_category_id()->count() }}</td>
                     <td>
                         <a class="btn btn-primary " href="{{ route('words_admin',['id' => $category->id]) }}" role="button">
                             <small>Add word</small>

--- a/resources/views/admin/admin_words.blade.php
+++ b/resources/views/admin/admin_words.blade.php
@@ -25,9 +25,6 @@
                     <th scope="row">{{ $word->japanese }}</th>
                     <td>{{ $word->explain }}</td>
                     <td>
-                        <a class="btn btn-primary " href="#" role="button">
-                            <small>Edit option</small>
-                        </a>
                         <a class="btn btn-primary " href="{{ route('edit_word_admin',['word_id' => $word->id]) }}" role="button">
                             <small>Edit</small>
                         </a>

--- a/resources/views/admin/edit_option.blade.php
+++ b/resources/views/admin/edit_option.blade.php
@@ -17,7 +17,7 @@
                             <label for="name" class="col-md-3 col-form-label text-md-right">Japanese</label>
 
                             <div class="col-md-7">
-                                <input id="name" type="text" class="form-control{{ $errors->has('japanese') ? ' is-invalid' : '' }}" value="{{ $word->japanese }}" disabled>
+                                <input id="name" type="text" class="form-control" value="{{ $word->japanese }}" disabled>
                             </div>
                         </div>
 
@@ -25,7 +25,7 @@
                             <label for="email" class="col-md-3 col-form-label text-md-right">Explanation</label>
 
                             <div class="col-md-7">
-                                <textarea　class="form-control{{ $errors->has('explain') ? ' is-invalid' : '' }}" id="" rows="10" disabled>{{ $word->explain }}</textarea>
+                                <textarea　class="form-control" id="" rows="10" disabled>{{ $word->explain }}</textarea>
                             </div>
                         </div>
 
@@ -59,32 +59,18 @@
                         </div>
                     </form>
 
-                    <form method="POST" action="{{ route('store_option_admin',['word_id' => $word->id]) }}">
+                    <form method="POST" action="{{ route('update_option_admin',['word_id' => $word->id]) }}">
 
                         @csrf
+                        @foreach($options as $key=>$option)
                         <div class="form-group row">
-                            <label for="name" class="col-md-3 col-form-label text-md-right">Option 1 (correct)</label>
+                            <label for="name" class="col-md-3 col-form-label text-md-right">Option{{$key+1}}</label>
 
                             <div class="col-md-7">
-                                <input id="name" type="text" class="form-control" name="option1" require>
+                                <input id="name" type="text" class="form-control" name="option{{ $key+1 }}" value="{{ $option->option_name }}" require>
                             </div>
                         </div>
-
-                        <div class="form-group row">
-                            <label for="name" class="col-md-3 col-form-label text-md-right">Option 2</label>
-
-                            <div class="col-md-7">
-                                <input id="name" type="text" class="form-control" name="option2" require>
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <label for="name" class="col-md-3 col-form-label text-md-right">Option 3</label>
-
-                            <div class="col-md-7">
-                                <input id="name" type="text" class="form-control" name="option3" require>
-                            </div>
-                        </div>
+                        @endforeach
 
                         <div class="form-group row mb-0">
                             <div class="col-md-7 offset-md-3">

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,6 +26,7 @@ Route::post('/admin/category/add_category/store', 'CategoryController@store_cate
 Route::get('/admin/category/{id}/edit', 'CategoryController@edit_category_admin')->name('edit_category_admin');
 Route::post('/admin/category/{id}/update', 'CategoryController@update_category_admin')->name('update_category_admin');
 Route::get('/admin/category/{id}/delete', 'CategoryController@delete_category_admin')->name('delete_category_admin');
+
 Route::get('/admin/category/{id}/words', 'WordController@words_admin')->name('words_admin');
 Route::get('/admin/category/{id}/words/add', 'WordController@add_word_admin')->name('add_word_admin');
 Route::post('/admin/category/{id}/words/add/store', 'WordController@store_word_admin')->name('store_word_admin');
@@ -33,13 +34,19 @@ Route::get('/admin/category/words/{word_id}/edit', 'WordController@edit_word_adm
 Route::post('/admin/category/words/{word_id}/edit/update', 'WordController@update_word_admin')->name('update_word_admin');
 Route::get('/admin/category/words/{word_id}/delete', 'WordController@delete_word_admin')->name('delete_word_admin');
 <<<<<<< Updated upstream
+<<<<<<< Updated upstream
 =======
+=======
+>>>>>>> Stashed changes
 
 Route::get('/admin/category/{word_id}/option/add', 'WordController@add_option_admin')->name('add_option_admin');
 Route::post('/admin/category/{word_id}/option/add/store', 'WordController@store_option_admin')->name('store_option_admin');
 Route::get('/admin/category/{word_id}/optioin/edit', 'WordController@edit_option_admin')->name('edit_option_admin');
 Route::post('/admin/category/{word_id}/option/edit/update', 'WordController@update_option_admin')->name('update_option_admin');
+<<<<<<< Updated upstream
 
 Route::get('/user/edit', 'UserController@edit_profile')->name('edit_profile');
 Route::post('/user/update', 'UserController@update_profile')->name('update_profile');
+>>>>>>> Stashed changes
+=======
 >>>>>>> Stashed changes


### PR DESCRIPTION
## Description / Purpose (checkpoints)
Implement word's option create and edit function.

Fixes issue: 
<link-to-your-spreadsheet> 
https://docs.google.com/spreadsheets/d/1KanXdYJuprUERp6mQZAxVSb1ssrIL67G0Akeesurc4E/edit?usp=sharing
<task-number>
5

## How To Test This PR
 1. After login as admin, click "category" button and go category page.
 2. Click "add word" button and click "add new word" button.
 3. Click register after fill out the form.
 4. Click submit after fill out "Add option" form.
 
 **Commands**
php artisan migrate

 **Screenshots**
Word list page
[![Screenshot from Gyazo](https://gyazo.com/371dbc632aa95d025a5febae37b31662/raw)](https://gyazo.com/371dbc632aa95d025a5febae37b31662)

Add and Edit word page
[![Screenshot from Gyazo](https://gyazo.com/05cfc0ddb89b7fb3f6480538cc90aac3/raw)](https://gyazo.com/05cfc0ddb89b7fb3f6480538cc90aac3)

Add and Edit option page
[![Screenshot from Gyazo](https://gyazo.com/e00a7209add746f8f1624780cdcef787/raw)](https://gyazo.com/e00a7209add746f8f1624780cdcef787)